### PR TITLE
Directly pass tmpfile.path() to Command::arg

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ fn prim() -> anyhow::Result<&'static str> {
         let editor = env::var("EDITOR").unwrap_or("vim".to_string());
         tmpfile.seek(SeekFrom::Start(0)).unwrap();
         let child = Command::new(editor)
-            .arg(tmpfile.path().to_str().unwrap().to_string())
+            .arg(tmpfile.path())
             .stdin(Stdio::piped())
             .stdout(Stdio::inherit())
             .spawn()


### PR DESCRIPTION
`tempfile.path()` returns a `PathBuf`, `Command::arg` accepts something that implements `AsRef<OsStr>`.  As `PathBuf` already implements `AsRef<OsStr>`, we can directly pass `tempfile.path()` to `Command::arg` instead of converting it to a `String`.