### PR TITLE
Improve error handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn find_renames(old_lines: String, new_lines: String) -> Result<Vec<Rename>, Ren
     Ok(renames)
 }
 
-fn prim() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
     let matches = App::new("renamer")
                           .version("1.0")
                           .author("Marcus B. <me@mbuffett.com")
@@ -123,10 +123,4 @@ fn prim() -> anyhow::Result<()> {
         println!("Aborting")
     }
     Ok(())
-}
-
-fn main() {
-    if let Err(err) = prim() {
-        println!("{}", err);
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use ansi_term::Colour;
 use clap::App;
 
+use anyhow::Context;
 use dialoguer::Confirm;
 use std::env;
 use std::fmt::Display;
@@ -72,7 +73,8 @@ fn main() -> anyhow::Result<()> {
         io::stdin().read_to_string(&mut buffer)?;
         buffer
     };
-    let mut tmpfile: tempfile::NamedTempFile = tempfile::NamedTempFile::new().unwrap();
+    let mut tmpfile: tempfile::NamedTempFile =
+        tempfile::NamedTempFile::new().context("Could not create temp file")?;
     {
         write!(tmpfile, "{}", input)?;
         let editor = env::var("EDITOR").unwrap_or("vim".to_string());
@@ -82,7 +84,7 @@ fn main() -> anyhow::Result<()> {
             .stdin(Stdio::piped())
             .stdout(Stdio::inherit())
             .spawn()
-            .expect("failed to execute process");
+            .context("Failed to execute editor process")?;
 
         child.wait_with_output()?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn find_renames(old_lines: String, new_lines: String) -> Result<Vec<Rename>, Ren
     Ok(renames)
 }
 
-fn prim() -> anyhow::Result<&'static str> {
+fn prim() -> anyhow::Result<()> {
     let matches = App::new("renamer")
                           .version("1.0")
                           .author("Marcus B. <me@mbuffett.com")
@@ -127,7 +127,7 @@ fn prim() -> anyhow::Result<&'static str> {
     if let Err(err) = replacements {
         println!("{}", err);
     }
-    Ok("")
+    Ok(())
 }
 
 fn main() {


### PR DESCRIPTION
This PR improves the error handling using both the built-in error handling tools and the anyhow crate.

You could also remove the custom error enum and the thiserror dependency.  It is typically only used for libraries because users might be interested in the exact type of the error.  For command-line applications, it is typically enough to just print an error message.  So for example, I would replace this code:

```rust
if replacements.is_empty() {
    println!("No replacements found");
    return Err(RenamerError::NoReplacementsFound.into());
}
```

with this:

```rust
if replacements.is_empty() {
    return Err(anyhow::anyhow!("No replacements found"));
}
```

Or using a helper macro from anyhow:

```rust
if replacements.is_empty() {
    anyhow::bail!("No replacements found");
}
```

Or even shorter:

```rust
anyhow::ensure!(!replacements.is_empty(), "No replacements found");
```