### PR TITLE
Use clap::crate_version macro to generate version

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ fn find_renames(old_lines: String, new_lines: String) -> Result<Vec<Rename>, Ren
 
 fn prim() -> anyhow::Result<&'static str> {
     let matches = App::new("renamer")
-                          .version("1.0")
+                          .version(clap::crate_version!())
                           .author("Marcus B. <me@mbuffett.com")
                           .about("Takes a list of files and renames/removes them, by piping them through an external editor")
                           .arg(


### PR DESCRIPTION
Using clap’s crate_version! macro, we can automatically generate the
version string based on the crate version defined in Cargo.toml.