### PR TITLE
Inherit stdio when opening the editor

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ fn main() -> anyhow::Result<()> {
         tmpfile.seek(SeekFrom::Start(0)).unwrap();
         let child = Command::new(editor)
             .arg(tmpfile.path())
-            .stdin(Stdio::piped())
+            .stdin(Stdio::inherit())
             .stdout(Stdio::inherit())
             .spawn()
             .context("Failed to execute editor process")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,6 @@ use std::fs;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 use std::process::Command;
-use std::process::Stdio;
 
 use thiserror::Error;
 
@@ -104,8 +103,6 @@ fn main() -> anyhow::Result<()> {
         tmpfile.seek(SeekFrom::Start(0)).unwrap();
         let child = Command::new(editor)
             .arg(tmpfile.path())
-            .stdin(Stdio::inherit())
-            .stdout(Stdio::inherit())
             .spawn()
             .context("Failed to execute editor process")?;
 


### PR DESCRIPTION
Fixes #3.  Hopefully, this doesn’t break anything for you.  But as this is the same as [`spawn_editor`](https://lib.rs/crates/spawn_editor) does when spawning an editor, I’m quite confident that it is correct.