### PR TITLE
Add pretty-diff option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +213,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "dialoguer",
+ "diff",
  "predicates",
  "shell-escape",
  "subprocess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tempfile = "3.1.0"
 dialoguer = "0.6.2"
 ansi_term = "0.12.1"
 shell-escape = "0.1.5"
+diff = "0.1.12"
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,15 +195,21 @@ fn main() -> anyhow::Result<()> {
         Colour::Yellow.paint("The following replacements were found:")
     );
     println!();
-    for replacement in &replacements {
-        if matches.is_present("pretty-diff") {
-            println!("{}", replacement.pretty_diff());
-            println!(""); // FIXME: How to properly add blank lines between diffs?
-        } else {
+
+    if matches.is_present("pretty-diff") {
+        let diff_output = replacements
+            .iter()
+            .map(|repl| repl.pretty_diff().to_string())
+            .collect::<Vec<String>>()
+            .join("\n\n"); // leave a blank line between pretty file diffs
+        println!("{}", diff_output);
+    } else {
+        for replacement in &replacements {
             println!("{}", Colour::Green.paint(replacement.to_string()));
         }
     }
     println!();
+
     if matches.is_present("yes")
         || Confirm::new()
             .with_prompt("Execute these renames?")

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use dialoguer::Confirm;
 use shell_escape::escape;
 use std::borrow::Cow;
 use std::env;
-use std::fmt::Display;
+use std::fmt::{Display, Formatter};
 use std::fs;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::Path;
@@ -14,15 +14,70 @@ use std::process::Command;
 
 use thiserror::Error;
 
+mod text_diff;
+use text_diff::{calculate_text_diff, TextDiff};
+
 #[derive(Debug, Clone)]
 struct Rename {
     original: String,
     new: String,
 }
 
+impl Rename {
+    fn pretty_diff(&self) -> impl Display {
+        struct PrettyDiff(Rename);
+        impl Display for PrettyDiff {
+            fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+                let diff_changes = calculate_text_diff(&self.0.original, &self.0.new);
+
+                // print old
+                write!(f, "{}", Colour::Red.paint("- "))?;
+                for change in diff_changes.iter() {
+                    match change {
+                        TextDiff::Removed(old) => {
+                            write!(f, "{}", Colour::Red.paint(old))?;
+                        },
+                        TextDiff::Unchanged(same) => {
+                            write!(f, "{}", same)?;
+                        },
+                        _ => (),
+                    }
+                }
+                writeln!(f)?;
+
+                // print new
+                write!(f, "{}", Colour::Green.paint("+ "))?;
+                for change in diff_changes.iter() {
+                    match change {
+                        TextDiff::New(new) => {
+                            write!(f, "{}", Colour::Green.paint(new))?;
+                        },
+                        TextDiff::Unchanged(same) => {
+                            write!(f, "{}", same)?;
+                        },
+                        _ => (),
+                    }
+                }
+
+                Ok(())
+            }
+        }
+        PrettyDiff(self.clone())
+    }
+
+    fn plain_diff(&self) -> impl Display {
+        struct PlainDiff(Rename);
+        impl Display for PlainDiff {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{} -> {}", self.0.original, self.0.new)
+            }
+        }
+        PlainDiff(self.clone())
+    }
+}
 impl Display for Rename {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} -> {}", self.original, self.new)
+        self.plain_diff().fmt(f)
     }
 }
 
@@ -73,6 +128,12 @@ fn main() -> anyhow::Result<()> {
                                .long("yes")
                                .short("y")
                                .help("Answer all prompts with yes")
+                               )
+                          .arg(
+                              clap::Arg::with_name("pretty-diff")
+                               .long("pretty-diff")
+                               .short("p")
+                               .help("Prettify diffs")
                                )
                           .arg(
                               clap::Arg::with_name("files")
@@ -135,7 +196,12 @@ fn main() -> anyhow::Result<()> {
     );
     println!();
     for replacement in &replacements {
-        println!("{}", Colour::Green.paint(replacement.to_string()));
+        if matches.is_present("pretty-diff") {
+            println!("{}", replacement.pretty_diff());
+            println!(""); // FIXME: How to properly add blank lines between diffs?
+        } else {
+            println!("{}", Colour::Green.paint(replacement.to_string()));
+        }
     }
     println!();
     if matches.is_present("yes")

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ impl Rename {
     }
 }
 impl Display for Rename {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         self.plain_diff().fmt(f)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ impl Rename {
 
                 // print old
                 write!(f, "{}", Colour::Red.paint("- "))?;
-                for change in diff_changes.iter() {
+                for change in &diff_changes {
                     match change {
                         TextDiff::Removed(old) => {
                             write!(f, "{}", Colour::Red.paint(old))?;
@@ -47,7 +47,7 @@ impl Rename {
 
                 // print new
                 write!(f, "{}", Colour::Green.paint("+ "))?;
-                for change in diff_changes.iter() {
+                for change in &diff_changes {
                     match change {
                         TextDiff::New(new) => {
                             write!(f, "{}", Colour::Green.paint(new))?;

--- a/src/text_diff.rs
+++ b/src/text_diff.rs
@@ -1,6 +1,6 @@
 use diff;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum TextDiff {
     Removed(String),
     Unchanged(String),
@@ -38,4 +38,22 @@ pub fn calculate_text_diff(old: &str, new: &str) -> Vec<TextDiff> {
         }
     }
     text_changes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_diff_works() {
+        let diff_changes = calculate_text_diff("old_file.txt", "newer_file.md");
+        assert_eq!(diff_changes, &[
+            // NOTE: removed is always first
+            TextDiff::Removed("old".to_owned()),
+            TextDiff::New("newer".to_owned()),
+            TextDiff::Unchanged("_file.".to_owned()),
+            TextDiff::Removed("txt".to_owned()),
+            TextDiff::New("md".to_owned()),
+        ]);
+    }
 }

--- a/src/text_diff.rs
+++ b/src/text_diff.rs
@@ -1,0 +1,41 @@
+use diff;
+
+#[derive(Debug)]
+pub enum TextDiff {
+    Removed(String),
+    Unchanged(String),
+    New(String),
+}
+
+pub fn calculate_text_diff(old: &str, new: &str) -> Vec<TextDiff> {
+    let mut text_changes = vec![];
+
+    // diff::chars() gives us the diff char by char, so we regroup consecutive
+    // character changes into strings for simpler manipulation.
+    for diff in diff::chars(old, new) {
+        match diff {
+            diff::Result::Left(l) => {
+                if let Some(TextDiff::Removed(old)) = text_changes.last_mut() {
+                    old.push(l)
+                } else {
+                    text_changes.push(TextDiff::Removed(String::from(l)))
+                }
+            },
+            diff::Result::Both(b, _) => {
+                if let Some(TextDiff::Unchanged(unchanged)) = text_changes.last_mut() {
+                    unchanged.push(b)
+                } else {
+                    text_changes.push(TextDiff::Unchanged(String::from(b)))
+                }
+            },
+            diff::Result::Right(r) => {
+                if let Some(TextDiff::New(new)) = text_changes.last_mut() {
+                    new.push(r)
+                } else {
+                    text_changes.push(TextDiff::New(String::from(r)))
+                }
+            },
+        }
+    }
+    text_changes
+}


### PR DESCRIPTION
Closes #18

It looks like this:
![pretty-diff](https://user-images.githubusercontent.com/9730330/111035317-2c2b8d80-841a-11eb-918d-78ea0039563c.png)


I'm using a new dependency to calculate the text diff: [diff](https://github.com/utkarshkukreti/diff.rs)

Bear with me I'm still a Rust beginner! :smiley:
I had a hard time choosing a way to switch display mode for `Rename` and I couldn't find nice&clean solutions on the web.
I ended up being inspired by https://www.reddit.com/r/rust/comments/9w59di/supporting_multiple_display_formats/e9ht01v using a wrapper struct implementing `Display`, but if you know a better way **I'm happy to learn** !

NOTE: Missing unit tests