### PR TITLE
Expand lone directories. (#24)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "pipe-rename"
-version = "1.1.4"
+version = "1.2.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pipe-rename"
-version = "1.1.4"
+version = "1.2.0"
 authors = ["Marcus Buffett <marcusbuffett@me.com>"]
 description = "Rename your files using your favorite text editor"
 homepage = "https://github.com/marcusbuffett/pipe-rename"

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -48,3 +48,13 @@ fn test_rename() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_dot() -> anyhow::Result<()> {
+    let mut test_case = TestCase::new()?;
+    let err = test_case.replace(".", ".");
+
+    assert!(err.is_err());
+
+    Ok(())
+}


### PR DESCRIPTION
When the input is a single directory, list the contents of the directory
instead. Mainly designed for the special directories like `.`, `..`, and
`~`.