### PR TITLE
Implement expansion of wildcards for Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +311,7 @@ dependencies = [
  "subprocess",
  "tempfile",
  "thiserror",
+ "wild",
 ]
 
 [[package]]
@@ -568,6 +575,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "wild"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b116685a6be0c52f5a103334cbff26db643826c7b3735fc0a3ba9871310a74"
+dependencies = [
+ "glob",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ dialoguer = "0.6.2"
 ansi_term = "0.12.1"
 shell-escape = "0.1.5"
 diff = "0.1.12"
+wild = "2"
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 use std::process::Command;
 use tempfile;
+use wild;
 
 use thiserror::Error;
 
@@ -338,7 +339,7 @@ impl Display for MenuItem {
 }
 
 fn main() -> anyhow::Result<()> {
-    let opts = Opts::parse();
+    let opts = Opts::parse_from(wild::args());
     let input_files = get_input_files(opts.files)?;
 
     check_input_files(&input_files)?;


### PR DESCRIPTION
- Implements expansion of wildcards ("globbing") via the 'wild' crate
- Should close issue #39

-----

Side-note: I noticed that `cargo test` gives me three errors, but it did that even prior to my changes. Is this known?