### PR TITLE
Fix issue #55

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,9 @@ wild = "2"
 [dev-dependencies]
 assert_cmd = "1.0.1"
 predicates = "1.0.5"
+
+# xref: https://bitshifter.github.io/rr+rust/#11
+# The development profile, used for `cargo build`
+[profile.dev]
+opt-level = 0  # Controls the --opt-level the compiler builds with
+debug = true   # Controls whether the compiler passes `-g`

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ impl Rename {
         // Expand ~ if applicable.
         let mut new = new.to_string();
         if let Ok(home) = env::var("HOME") {
-            if &new[..2] == "~/" {
+            if new.starts_with("~/") {
                 new = new.replacen("~", &home, 1);
             }
         }


### PR DESCRIPTION
- This fixes an issue where we attempt to create a slice of bytes from a string, assuming that two bytes doesn't end up in the middle of a Unicode code point. Instead of comparing against the slice of bytes the code now uses the String::starts_with() method to compare against the same &str.
- Also adds a dev profile to Cargo.toml, which enables debug symbols and turns down optimization.

-----

I attempted to create a test case for this, but it appears that none of the current tests even goes through `Rename::new` ... no idea why.

Here's the diff:

```
diff --git a/tests/rename.rs b/tests/rename.rs
index ad0290c..6080c1f 100644
--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -1,6 +1,7 @@
 mod run;

 use run::TestCase;
+use std::str;

 #[test]
 fn test_one_file() -> anyhow::Result<()> {
@@ -37,6 +38,21 @@ fn test_with_space() -> anyhow::Result<()> {
     Ok(())
 }

+// Tests #55 which was caused by creating a byte slice from a string
+#[test]
+fn test_with_surrogates() -> anyhow::Result<()> {
+    let mut test_case = TestCase::new()?;
+    test_case.replace("aäoöuü", "aæoöuü")?;
+    let sparkle_heart = vec![240, 159, 146, 150]; // codepoint made up by 4 code units
+    let sparkle_heart = str::from_utf8(&sparkle_heart).unwrap();
+    test_case.replace(sparkle_heart, "foobar")?;
+
+    test_case.assert_run()?;
+    test_case.assert_renamed()?;
+
+    Ok(())
+}
+
 #[test]
 fn test_option() -> anyhow::Result<()> {
     let mut test_case = TestCase::new()?;
```

[Inspired by this example](https://doc.rust-lang.org/stable/std/str/fn.from_utf8.html#examples)