### PR TITLE
Only rename filenames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "os_str_bytes"
@@ -528,7 +528,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -577,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45b6ddbb36c5b969c182aec3c4a0bce7df3fbad4b77114706a49aacc80567388"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -656,7 +656,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
 ]
 
 [[package]]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::env;
 use std::fmt::{Display, Formatter};
 use std::fs;
 use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::iter::zip;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -44,6 +45,9 @@ struct Opts {
     /// Undo the previous renaming operation
     #[clap(short, long)]
     undo: bool,
+    /// Rename only filenames
+    #[clap(short = 'n', long)]
+    filenames_only: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -206,13 +210,48 @@ fn expand_dir(path: &str) -> anyhow::Result<Vec<String>, io::Error> {
         .collect())
 }
 
-fn open_editor(input_files: &[String], editor_string: &str) -> anyhow::Result<Vec<String>> {
+/** Split path into directory path and filename. */
+fn path_and_file_name(line: &String) -> Option<(PathBuf, String)> {
+    let path = PathBuf::from(line);
+    let dirname = path.parent().and_then(|p| Some(PathBuf::from(p)));
+    let file_name = path
+        .file_name()
+        .and_then(|f| f.to_os_string().into_string().ok());
+
+    match (dirname, file_name) {
+        (Some(d), Some(f)) => Some((d, f)),
+        _ => None,
+    }
+}
+
+fn open_editor(
+    input_files: &[String],
+    editor_string: &str,
+    filenames_only: bool,
+) -> anyhow::Result<Vec<String>> {
     let mut tmpfile = tempfile::Builder::new()
         .prefix("renamer-")
         .suffix(".txt")
         .tempfile()
         .context("Could not create temp file")?;
-    write!(tmpfile, "{}", input_files.join("\n"))?;
+
+    let components: Vec<(PathBuf, String)> =
+        input_files.iter().filter_map(path_and_file_name).collect();
+
+    if filenames_only {
+        write!(
+            tmpfile,
+            "{}",
+            components
+                .iter()
+                .map(|(_, filename)| filename.to_owned())
+                .collect::<Vec<_>>()
+                .join("\n")
+        )?;
+    } else {
+        write!(tmpfile, "{}", input_files.join("\n"))?;
+    }
+
     let editor_parsed = shell_words::split(editor_string)
         .expect("failed to parse command line flags in EDITOR command");
     tmpfile.seek(SeekFrom::Start(0))?;
@@ -232,10 +271,19 @@ fn open_editor(input_files: &[String], editor_string: &str) -> anyhow::Result<Ve
         bail!("Editor terminated unexpectedly. Aborting.");
     }
 
-    Ok(fs::read_to_string(&tmpfile)?
+    let changes: Vec<_> = fs::read_to_string(&tmpfile)?
         .lines()
         .map(|f| f.to_string())
-        .collect())
+        .collect();
+
+    // Add the path back to the filename.
+    if filenames_only {
+        return Ok(zip(components, changes)
+            .map(|(parts, file_name)| parts.0.join(file_name).display().to_string())
+            .collect());
+    }
+
+    Ok(changes)
 }
 
 fn check_for_existing_files(replacements: &[Rename], force: bool) -> anyhow::Result<()> {
@@ -320,7 +368,7 @@ fn execute_renames(
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     let dir = &replacement.new.parent();
                     if let Some(dir) = dir {
-                        fs::create_dir_all(&dir)?;
+                        fs::create_dir_all(dir)?;
                         fs::rename(&replacement.original, &replacement.new)?;
                     }
                 }
@@ -442,7 +490,7 @@ fn main() -> anyhow::Result<()> {
     let mut buffer = input_files.clone();
 
     loop {
-        let new_files = open_editor(&buffer, &editor)?;
+        let new_files = open_editor(&buffer, &editor, opts.filenames_only)?;
         let replacements = find_renames(&input_files, &new_files)?;
         println!();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ struct Opts {
     /// Undo the previous renaming operation
     #[clap(short, long)]
     undo: bool,
-    /// Rename only filenames
+    /// Only rename filenames
     #[clap(short = 'n', long)]
     filename_only: bool,
 }
@@ -235,16 +235,17 @@ fn open_editor(
         .tempfile()
         .context("Could not create temp file")?;
 
-    let components: Vec<(PathBuf, String)> =
-        input_files.iter().filter_map(path_and_file_name).collect();
+    let mut components: Vec<(PathBuf, String)> = vec![];
 
     if filename_only {
+        components = input_files.iter().filter_map(path_and_file_name).collect();
+
         write!(
             tmpfile,
             "{}",
             components
                 .iter()
-                .map(|(_, filename)| filename.to_owned())
+                .map(|(_, filename)| filename.to_string())
                 .collect::<Vec<_>>()
                 .join("\n")
         )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ struct Opts {
     undo: bool,
     /// Only rename filenames
     #[clap(short = 'n', long)]
-    filename_only: bool,
+    filenames_only: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -227,7 +227,7 @@ fn path_and_file_name(line: &String) -> Option<(PathBuf, String)> {
 fn open_editor(
     input_files: &[String],
     editor_string: &str,
-    filename_only: bool,
+    filenames_only: bool,
 ) -> anyhow::Result<Vec<String>> {
     let mut tmpfile = tempfile::Builder::new()
         .prefix("renamer-")
@@ -237,7 +237,7 @@ fn open_editor(
 
     let mut components: Vec<(PathBuf, String)> = vec![];
 
-    if filename_only {
+    if filenames_only {
         components = input_files.iter().filter_map(path_and_file_name).collect();
 
         write!(
@@ -278,7 +278,7 @@ fn open_editor(
         .collect();
 
     // Add the path back to the filename.
-    if filename_only {
+    if filenames_only {
         return Ok(zip(components, changes)
             .map(|(parts, file_name)| parts.0.join(file_name).display().to_string())
             .collect());
@@ -491,7 +491,7 @@ fn main() -> anyhow::Result<()> {
     let mut buffer = input_files.clone();
 
     loop {
-        let new_files = open_editor(&buffer, &editor, opts.filename_only)?;
+        let new_files = open_editor(&buffer, &editor, opts.filenames_only)?;
         let replacements = find_renames(&input_files, &new_files)?;
         println!();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ struct Opts {
     undo: bool,
     /// Rename only filenames
     #[clap(short = 'n', long)]
-    filenames_only: bool,
+    filename_only: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -227,7 +227,7 @@ fn path_and_file_name(line: &String) -> Option<(PathBuf, String)> {
 fn open_editor(
     input_files: &[String],
     editor_string: &str,
-    filenames_only: bool,
+    filename_only: bool,
 ) -> anyhow::Result<Vec<String>> {
     let mut tmpfile = tempfile::Builder::new()
         .prefix("renamer-")
@@ -238,7 +238,7 @@ fn open_editor(
     let components: Vec<(PathBuf, String)> =
         input_files.iter().filter_map(path_and_file_name).collect();
 
-    if filenames_only {
+    if filename_only {
         write!(
             tmpfile,
             "{}",
@@ -277,7 +277,7 @@ fn open_editor(
         .collect();
 
     // Add the path back to the filename.
-    if filenames_only {
+    if filename_only {
         return Ok(zip(components, changes)
             .map(|(parts, file_name)| parts.0.join(file_name).display().to_string())
             .collect());
@@ -490,7 +490,7 @@ fn main() -> anyhow::Result<()> {
     let mut buffer = input_files.clone();
 
     loop {
-        let new_files = open_editor(&buffer, &editor, opts.filenames_only)?;
+        let new_files = open_editor(&buffer, &editor, opts.filename_only)?;
         let replacements = find_renames(&input_files, &new_files)?;
         println!();
 


### PR DESCRIPTION
Adds `--filenames-only` and `-n` flags. Strips the path away when passing the files to the editor and then adds them back before renaming.

Implements #16 