### PR TITLE
Put directory creation behind a `-p` flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,13 @@ ARGS:
 
 OPTIONS:
     -c, --rename-command <COMMAND>
-            Optionally set a custom rename command, like 'git mv'
+            Use a custom rename command, like 'git mv'
+
+    -d, --pretty-diff
+            Prettify diffs
 
     -e, --editor <EDITOR>
-            Optionally set an editor, overriding EDITOR environment variable and default
+            Specify what editor to use
 
     -f, --force
             Overwrite existing files
@@ -66,8 +69,8 @@ OPTIONS:
     -n, --filenames-only
             Only rename filenames
 
-    -p, --pretty-diff
-            Prettify diffs
+    -p, --parents
+            Create parent directories if needed
 
     -u, --undo
             Undo the previous renaming operation
@@ -77,6 +80,7 @@ OPTIONS:
 
     -y, --yes
             Answer all prompts with yes
+
 ```
 
 ### Caveat emptor

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ OPTIONS:
     -p, --parents
             Create parent directories if needed
 
+    -q, --quiet
+            Skip printing replacement filenames
+
     -u, --undo
             Undo the previous renaming operation
 
@@ -80,7 +83,6 @@ OPTIONS:
 
     -y, --yes
             Answer all prompts with yes
-
 ```
 
 ### Caveat emptor

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,10 @@ struct Opts {
     #[clap(short, long)]
     parents: bool,
 
+    /// Skip printing replacement filenames
+    #[clap(short, long)]
+    quiet: bool,
+
     /// Only rename filenames
     #[clap(short = 'n', long)]
     filenames_only: bool,
@@ -535,7 +539,9 @@ fn main() -> anyhow::Result<()> {
 
         let menu_options = match check_existing {
             Ok(()) => {
-                print_replacements(&replacements, opts.pretty_diff);
+                if !opts.quiet {
+                    print_replacements(&replacements, opts.pretty_diff);
+                }
                 vec![MenuItem::Yes, MenuItem::No, MenuItem::Edit, MenuItem::Reset]
             }
             e @ Err(_) if opts.assume_yes => return e,

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -76,3 +76,16 @@ fn test_dot() {
 fn test_dotdot() {
     let _ = run_with_env(&[".."], &[".."], true);
 }
+
+#[test]
+fn test_new_dir() -> anyhow::Result<()> {
+    let mut test_case = TestCase::new()?;
+    test_case.replace("1", "a/1")?;
+
+    let assert = test_case.run()?;
+    assert
+        .failure()
+        .stderr("Error: No such file or directory (os error 2)\n");
+
+    Ok(())
+}


### PR DESCRIPTION
Currently if you rename files to a new directory that doesn't exist, pipe-rename will create parent directories for you. 

I'm not a fan of this being the default behavior for a couple reasons:
- More than once I've created new directories I did not intend to due to a typo.
- This makes its behavior align more closely with `mkdir -p` and tools like `mv` and `cp` which will not create parent directories by default.

For these reasons I'm moving parent directory creation behind a `-p` `--parents` flag.

`--pretty-diff`'s short command has been changed to `-d` as a result.